### PR TITLE
Import Type for MermaidProps

### DIFF
--- a/src/Mermaid/props.ts
+++ b/src/Mermaid/props.ts
@@ -1,3 +1,3 @@
 import mermaidAPI from 'mermaid/mermaidAPI';
 
-export type MermaidProps = { config: mermaidAPI.Config }
+export type MermaidProps = { config?: mermaidAPI.Config }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -19,7 +19,8 @@ import {
   TechDocsAddonLocations,
 } from '@backstage/plugin-techdocs-react';
 
-import { MermaidAddon, MermaidProps } from './Mermaid';
+import { MermaidAddon } from './Mermaid';
+import type { MermaidProps } from './Mermaid';
 
 /**
  * The TechDocs addons mermaid plugin


### PR DESCRIPTION
fixes #8 

Updates plugin.ts to import type instead of import for MermaidProps.
Makes config optional in MermaidProps to accept all defaults.