### PR TITLE
Add mermaid directive support

### DIFF
--- a/src/Mermaid/hooks.test.ts
+++ b/src/Mermaid/hooks.test.ts
@@ -1,0 +1,53 @@
+import { isMermaidCode } from "./hooks";
+
+describe("isMermaidCode", () => {
+  describe("returns true when", () => {
+    it("mermaid code exists", () => {
+      const mermaidCode = "sequenceDiagram foo foo2 foo-->foo2";
+
+      const result = isMermaidCode(mermaidCode);
+
+      expect(result).toBe(true);
+    });
+
+    it("mermaid code exists with directive", () => {
+      const mermaidCode = `%%{init: { 'logLevel': 'debug', 'theme': 'dark' } }%%
+graph LR
+A-->B`;
+
+      const result = isMermaidCode(mermaidCode);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("returns false when", () => {
+    it("contains no mermaid code", () => {
+      const mermaidCode = "this isnt mermaid code";
+
+      const result = isMermaidCode(mermaidCode);
+
+      expect(result).toBe(false);
+    });
+
+    it("mermaid directive but not mermaid start keyword", () => {
+      const mermaidCode = `%%{init: { 'logLevel': 'debug', 'theme': 'dark' } }%%
+invalid LR
+A-->B`;
+
+      const result = isMermaidCode(mermaidCode);
+
+      expect(result).toBe(false);
+    });
+
+    it("improper directive", () => {
+      const mermaidCode = `%%{init: { 'logLevel': 'debug', 'theme': 'dark' } 
+invalid LR
+A-->B`;
+
+      const result = isMermaidCode(mermaidCode);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/Mermaid/hooks.ts
+++ b/src/Mermaid/hooks.ts
@@ -14,8 +14,18 @@
  * limitations under the License.
  */
 
-const mermaidStart = /^(\s*)(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|requirementDiagram|gitGraph)/;
+const mermaidStart =
+  /^(\s*)(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|requirementDiagram|gitGraph)/;
 
 export const isMermaidCode = (code: string): boolean => {
-  return code.match(mermaidStart) !== null
-}
+  if (code.startsWith("%%{init")) {
+    const codeSplitByDirectiveStart = code.split("%%");
+
+    if (codeSplitByDirectiveStart.length < 3)
+      return code.match(mermaidStart) !== null;
+
+    return code.split("%%")[2].match(mermaidStart) !== null;
+  }
+
+  return code.match(mermaidStart) !== null;
+};

--- a/src/Mermaid/hooks.ts
+++ b/src/Mermaid/hooks.ts
@@ -18,13 +18,11 @@ const mermaidStart =
   /^(\s*)(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|requirementDiagram|gitGraph)/;
 
 export const isMermaidCode = (code: string): boolean => {
-  if (code.startsWith("%%{init")) {
-    const codeSplitByDirectiveStart = code.split("%%");
+  if (code.startsWith('%%{init')) {
+    const codeSplitByDirectiveStart = code.split('%%');
 
-    if (codeSplitByDirectiveStart.length < 3)
-      return code.match(mermaidStart) !== null;
-
-    return code.split("%%")[2].match(mermaidStart) !== null;
+    if (codeSplitByDirectiveStart.length > 2)
+      return code.split('%%')[2].match(mermaidStart) !== null;
   }
 
   return code.match(mermaidStart) !== null;


### PR DESCRIPTION
Currently the plugin does not handle [mermaid directives](https://mermaid.js.org/config/directives.html#directives-1). This is because the `isMermaidCode` check just checks the keyword the mermaid diagram starts with, which will always return false since Mermaid directives have to be first. I added handling to run the check against with the directive removed if included.