### PR TITLE
Fix typo in C4Context

### DIFF
--- a/src/Mermaid/hooks.ts
+++ b/src/Mermaid/hooks.ts
@@ -15,7 +15,7 @@
  */
 
 const mermaidStart =
-  /^(\s*)(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|requirementDiagram|gitGraph|C4Contex|C4Container|C4Component|C4Dynamic|C4Deployment|timeline)/;
+  /^(\s*)(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|requirementDiagram|gitGraph|C4Context|C4Container|C4Component|C4Dynamic|C4Deployment|timeline)/;
 
 export const isMermaidCode = (code: string): boolean => {
   if (code.startsWith('%%{init')) {


### PR DESCRIPTION
C4Contex should be C4Context.

This works today because C4Contex is a prefix of C4Context. Fixing for clarity.