### PR TITLE
fix: support mermaid diagrams with frontmatter directives

### DIFF
--- a/src/Mermaid/hooks.test.ts
+++ b/src/Mermaid/hooks.test.ts
@@ -57,6 +57,19 @@ A-->B`;
 
       expect(isMermaidCode(mermaidCode)).toBe(true);
     })
+
+    it("mermaid code exists with frontmatter", () => {
+      const mermaidCode = `---
+title: class diagram with frontmatter
+---
+classDiagram
+    direction LR`;
+
+      const result = isMermaidCode(mermaidCode);
+
+      expect(result).toBe(true);
+    });
+
   });
 
   describe("returns false when", () => {

--- a/src/Mermaid/hooks.test.ts
+++ b/src/Mermaid/hooks.test.ts
@@ -70,6 +70,16 @@ classDiagram
       expect(result).toBe(true);
     });
 
+    it("mermaid code exists with comment", () => {
+      const mermaidCode = `%% mermaid code with comment
+graph LR
+A-->B`;
+
+      const result = isMermaidCode(mermaidCode);
+
+      expect(result).toBe(true);
+    });
+
   });
 
   describe("returns false when", () => {

--- a/src/Mermaid/hooks.ts
+++ b/src/Mermaid/hooks.ts
@@ -15,7 +15,7 @@
  */
 
 const mermaidStart =
-  /^(\s*)(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|requirementDiagram|gitGraph|C4Context|C4Container|C4Component|C4Dynamic|C4Deployment|timeline)/;
+  /^(\s*)(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|requirementDiagram|gitGraph|C4Context|C4Container|C4Component|C4Dynamic|C4Deployment|timeline)/gm;
 
 export const isMermaidCode = (code: string): boolean => {
   if (code.startsWith('%%{init')) {


### PR DESCRIPTION
Support diagrams containing frontmatter directive. Might fix https://github.com/johanneswuerbach/backstage-plugin-techdocs-addon-mermaid/issues/48

Possibly a bit naive solution that seems to work, perhaps even the `codeSplitByDirectiveStart` block can be removed to with this fix?