### PR TITLE
Add four missing diagrams, provide contributor instructions, and update mermaid.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,32 @@ markdown_extensions:
 
 ## Contributors Guide
 
-If you want to do full end-to-end test and development, follow the instructions below.
+After making changes to the plugin and having unit tests pass, to do manual end-to-end testing, follow the instructions below.
 
-1. This plugin can be developed in the context of an existing Backstage deployment or a [new local deployment](https://backstage.io/docs/getting-started/#1-create-your-backstage-app).
-1. Fork and clone this repo into the plugins folder of your app.
-1. To have yarn link the local version of the addon instead of the version on npm.
-  1. Change directory to the new plugins/backstage-plugin-techdocs-addon-mermaid folder, run `yarn link`
-  2. Go back to the main backstage directory and run `yarn link "backstage-plugin-techdocs-addon-mermaid`
-1. Run `yarn install` in the repo.
-1. Follow the above the instructions to add the plugin to your TechDocs pages in your Backstage deployment.
-2. 
+This plugin can be developed in the context of an existing Backstage deployment or a [new local deployment](https://backstage.io/docs/getting-started/#1-create-your-backstage-app).
+
+1. Fork and clone this repo into the plugins folder of your Backstage codebase.
+2. To have yarn link the local version of the addon instead of the version on npm.
+  1. Change directories to the new `plugins/backstage-plugin-techdocs-addon-mermaid folder` and run `yarn link`.
+  2. Go up to the main Backstage directory and run `yarn link "backstage-plugin-techdocs-addon-mermaid`.
+3. Run `yarn install` in the Backstage root.
+4. Follow the earlier instructions to add the plugin to your TechDocs pages in your Backstage deployment such as `app.tsx`.
+
+You can either use the [TechDocs CLI](https://backstage.io/docs/features/techdocs/cli/) to test against a local docs folder. You will need to customize the preview app bundle for that to work as the addon is not included in the [standard bundle](https://github.com/backstage/techdocs-cli/blob/main/packages/embedded-techdocs-app/src/App.tsx).
+
+Otherwise, you will need to register a component via URL like any other Backstage component and view that component's TechDocs.
+
+For example, to use the SampleDocs component in this repo:
+
+1. Generate a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for *public repos*.
+2. Add the [GitHub integration](https://backstage.io/docs/integrations/github/locations) to your `app-config.local.yaml`.
+3. `yarn dev` in the root of your Backstage codebase.
+4. To register the demo docs, browse to `http://localhost:3000/catalog-import`
+5. Register the URL pointing to the SampleDocs/catalog-info.yaml, example: `https://github.com/johanneswuerbach/backstage-plugin-techdocs-addon-mermaid/blob/main/sampledocs/catalog-info.yaml`
+6. To iterate:
+   1. Create a branch for the addon.
+   2. Change the contents of the sampledocs.
+   3. Commit and push.
+   4. Register the catalog-info.yaml for your branch instead (keep in mind any security changes required for your personal access token).
+   5. Iterate changes to markdown and changes to the plugin.
    

--- a/README.md
+++ b/README.md
@@ -93,4 +93,3 @@ For example, to use the SampleDocs component in this repo:
    3. Commit and push.
    4. Register the catalog-info.yaml for your branch instead (keep in mind any security changes required for your personal access token).
    5. Iterate changes to markdown and changes to the plugin.
-   

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ graph TD;
 
 ## Auto-Detection vs. Manual Detection
 
-By default, this plugin will autodetect diagrams based on the starting token of the code block. In some cases, however, this auto-detection is not sufficient, for example because of an unrecognized 
+By default, this plugin will autodetect diagrams based on the starting token of the code block. In some cases, however, this auto-detection is not sufficient, for example, because of an unrecognized 
 diagram type or the use of front matter. In these cases, you can force the use of mermaid on blocks by adding configuration like this to your `mkdocs.yaml` file:
 
 ```yaml
@@ -65,9 +65,9 @@ markdown_extensions:
 
 ## Contributors Guide
 
-After making changes to the plugin and having unit tests pass, to do manual end-to-end testing, follow the instructions below.
-
 This plugin can be developed in the context of an existing Backstage deployment or a [new local deployment](https://backstage.io/docs/getting-started/#1-create-your-backstage-app).
+
+### Setup for Deployment
 
 1. Fork and clone this repo into the plugins folder of your Backstage codebase.
 2. To have yarn link the local version of the addon instead of the version on npm.
@@ -76,10 +76,17 @@ This plugin can be developed in the context of an existing Backstage deployment 
 3. Run `yarn install` in the Backstage root.
 4. Follow the earlier instructions to add the plugin to your TechDocs pages in your Backstage deployment such as `app.tsx`.
 
-You can either use the [TechDocs CLI](https://backstage.io/docs/features/techdocs/cli/) to test against a local docs folder. You will need to customize the preview app bundle for that to work as the addon is not included in the [standard bundle](https://github.com/backstage/techdocs-cli/blob/main/packages/embedded-techdocs-app/src/App.tsx).
+### Manual Testing
 
-Otherwise, you will need to register a component via URL like any other Backstage component and view that component's TechDocs.
+After making changes to the plugin and having unit tests pass, to do manual end-to-end testing, follow the instructions below.
 
+#### Option #1 Techdocs CLI
+
+You can use the [TechDocs CLI](https://backstage.io/docs/features/techdocs/cli/) to test against a local docs folder. You will need to customize the preview app bundle for that to work as the addon is not included in the [standard bundle](https://github.com/backstage/techdocs-cli/blob/main/packages/embedded-techdocs-app/src/App.tsx). Review the TechDoc's documentation for further instructions.
+
+#### Option #2 Use a Remote Location
+
+Register a component via URL like any other Backstage component and view that component's TechDocs. 
 For example, to use the SampleDocs component in this repo:
 
 1. Generate a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for *public repos*.
@@ -93,3 +100,9 @@ For example, to use the SampleDocs component in this repo:
    3. Commit and push.
    4. Register the catalog-info.yaml for your branch instead (keep in mind any security changes required for your personal access token).
    5. Iterate changes to markdown and changes to the plugin.
+
+### Merging Pull Requests
+
+1. Change the minor or patch version in package.json depending on the type of change.
+2. Run `yarn install`
+3. Commit and start a PR of your fork's branch.

--- a/README.md
+++ b/README.md
@@ -100,9 +100,3 @@ For example, to use the SampleDocs component in this repo:
    3. Commit and push.
    4. Register the catalog-info.yaml for your branch instead (keep in mind any security changes required for your personal access token).
    5. Iterate changes to markdown and changes to the plugin.
-
-### Merging Pull Requests
-
-1. Change the minor or patch version in package.json depending on the type of change.
-2. Run `yarn install`
-3. Commit and start a PR of your fork's branch.

--- a/README.md
+++ b/README.md
@@ -62,3 +62,17 @@ markdown_extensions:
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
 ```
+
+## Contributors Guide
+
+If you want to do full end-to-end test and development, follow the instructions below.
+
+1. This plugin can be developed in the context of an existing Backstage deployment or a [new local deployment](https://backstage.io/docs/getting-started/#1-create-your-backstage-app).
+1. Fork and clone this repo into the plugins folder of your app.
+1. To have yarn link the local version of the addon instead of the version on npm.
+  1. Change directory to the new plugins/backstage-plugin-techdocs-addon-mermaid folder, run `yarn link`
+  2. Go back to the main backstage directory and run `yarn link "backstage-plugin-techdocs-addon-mermaid`
+1. Run `yarn install` in the repo.
+1. Follow the above the instructions to add the plugin to your TechDocs pages in your Backstage deployment.
+2. 
+   

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "4.0.0-alpha.61",
-    "mermaid": "^10.3.0",
+    "mermaid": "^10.9.1",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-techdocs-addon-mermaid",
-  "version": "0.13.0",
+  "version": "0.12.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-techdocs-addon-mermaid",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",

--- a/sampledocs/catalog-info.yaml
+++ b/sampledocs/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sampledocs
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: documentation
+  lifecycle: production
+  owner: you

--- a/sampledocs/docs/index.md
+++ b/sampledocs/docs/index.md
@@ -1,0 +1,62 @@
+# Examples
+
+# Combined Mermaid Diagram Example
+
+```mermaid
+graph TD
+    A[Start] --> B{Is it working?}
+    B -- Yes --> C[Continue]
+    B -- No --> D[Fix it]
+    D --> B
+    C --> E[Finish]
+```
+
+```mermaid
+sequenceDiagram
+    participant Alice
+    participant Bob
+    Alice->>Bob: Hello Bob, how are you?
+    Bob-->>Alice: I'm good thanks!
+    Alice->>Bob: Great to hear
+```
+
+```mermaid
+gantt
+    title A Gantt Diagram
+    dateFormat  YYYY-MM-DD
+    section Section
+    Task 1           :a1, 2023-01-01, 30d
+    Task 2           :after a1  , 20d
+    Task 3           : 2023-02-11  , 20d
+    Task 4           : 2023-02-21  , 20d
+```
+
+```mermaid
+classDiagram
+    class Animal {
+      +String species
+      +void eat()
+    }
+    class Dog {
+      +String breed
+      +void bark()
+    }
+    Animal <|-- Dog
+```
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Working : start
+    Working --> Idle : stop
+    Working --> Failed : error
+```
+
+```mermaid
+pie
+    title Language Popularity
+    "JavaScript" : 50
+    "Python" : 25
+    "Java" : 15
+    "C++" : 10
+```

--- a/sampledocs/docs/index.md
+++ b/sampledocs/docs/index.md
@@ -214,6 +214,16 @@ columns 1
   style B fill:#969,stroke:#333,stroke-width:4px
 ```
 
+### Katex
+
+```mermaid
+graph LR
+    A["$$f(\relax{x}) = \int_{-\infty}^\infty \hat{f}(\xi)\,e^{2 \pi i \xi x}\,d\xi$$"] -->|"$$\Bigg(\bigg(\Big(\big((\frac{-b\pm\sqrt{b^2-4ac}}{2a})\big)\Big)\bigg)\Bigg)$$"| B("$$1+\frac{e^{-2\pi}} {1+\frac{e^{-4\pi}} {1+\frac{e^{-6\pi}} {1+\frac{e^{-8\pi}} {1+\cdots}}}}$$")
+    A -->|"$$\overbrace{a+b+c}^{\text{note}}$$"| C("$$\phase{-78^\circ}$$")
+    B --> D("$$x = \begin{cases} a &\text{if } b \\ c &\text{if } d \end{cases}$$")
+    C --> E("$$x(t)=c_1\begin{bmatrix}-\cos{t}+\sin{t}\\ 2\cos{t} \end{bmatrix}e^{2t}$$")
+```
+
 ## Not yet supported
 
 ### ZenUml
@@ -225,3 +235,4 @@ zenuml
     John->Alice: Great!
     Alice->John: See you later!
 ```
+

--- a/sampledocs/docs/index.md
+++ b/sampledocs/docs/index.md
@@ -60,3 +60,134 @@ pie
     "Java" : 15
     "C++" : 10
 ```
+
+```mermaid
+erDiagram
+    CUSTOMER ||--o{ ORDER : places
+    ORDER ||--|{ LINE-ITEM : contains
+    CUSTOMER }|..|{ DELIVERY-ADDRESS : uses
+```
+
+```mermaid
+journey
+    title My working day
+    section Go to work
+      Make tea: 5: Me
+      Go upstairs: 3: Me
+      Do work: 1: Me, Cat
+    section Go home
+      Go downstairs: 5: Me
+      Sit down: 5: Me
+```
+
+```mermaid
+quadrantChart
+    title Reach and engagement of campaigns
+    x-axis Low Reach --> High Reach
+    y-axis Low Engagement --> High Engagement
+    quadrant-1 We should expand
+    quadrant-2 Need to promote
+    quadrant-3 Re-evaluate
+    quadrant-4 May be improved
+    Campaign A: [0.3, 0.6]
+    Campaign B: [0.45, 0.23]
+    Campaign C: [0.57, 0.69]
+    Campaign D: [0.78, 0.34]
+    Campaign E: [0.40, 0.34]
+    Campaign F: [0.35, 0.78]
+```
+
+```mermaid
+    requirementDiagram
+
+    requirement test_req {
+    id: 1
+    text: the test text.
+    risk: high
+    verifymethod: test
+    }
+
+    element test_entity {
+    type: simulation
+    }
+
+    test_entity - satisfies -> test_req
+```
+
+```mermaid
+gitGraph
+   commit
+   commit
+   branch develop
+   checkout develop
+   commit
+   commit
+   checkout main
+   merge develop
+   commit
+   commit
+```
+
+```mermaid
+mindmap
+  root((mindmap))
+    Origins
+      Long history
+      ::icon(fa fa-book)
+      Popularisation
+        British popular psychology author Tony Buzan
+    Research
+      On effectiveness<br/>and features
+      On Automatic creation
+        Uses
+            Creative techniques
+            Strategic planning
+            Argument mapping
+    Tools
+      Pen and paper
+      Mermaid
+```
+
+```mermaid
+timeline
+    title History of Social Media Platform
+    2002 : LinkedIn
+    2004 : Facebook
+         : Google
+    2005 : Youtube
+    2006 : Twitter
+```
+
+```mermaid
+zenuml
+    title Demo
+    Alice->John: Hello John, how are you?
+    John->Alice: Great!
+    Alice->John: See you later!
+```
+
+```mermaid
+xychart-beta
+    title "Sales Revenue"
+    x-axis [jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec]
+    y-axis "Revenue (in $)" 4000 --> 11000
+    bar [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]
+    line [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]
+```
+
+```mermaid
+block-beta
+columns 1
+  db(("DB"))
+  blockArrowId6<["&nbsp;&nbsp;&nbsp;"]>(down)
+  block:ID
+    A
+    B["A wide one in the middle"]
+    C
+  end
+  space
+  D
+  ID --> D
+  C --> D
+  style B fill:#969,stroke:#333,stroke-width:4px
+```

--- a/sampledocs/docs/index.md
+++ b/sampledocs/docs/index.md
@@ -1,6 +1,8 @@
-# Examples
+# Example Supported Mermaid Diagrams
 
-# Combined Mermaid Diagram Example
+## Supported by the Add On
+
+## Graph/Flowchart
 
 ```mermaid
 graph TD
@@ -11,6 +13,8 @@ graph TD
     C --> E[Finish]
 ```
 
+### Sequence Diagram
+
 ```mermaid
 sequenceDiagram
     participant Alice
@@ -19,6 +23,8 @@ sequenceDiagram
     Bob-->>Alice: I'm good thanks!
     Alice->>Bob: Great to hear
 ```
+
+### Gantt
 
 ```mermaid
 gantt
@@ -30,6 +36,8 @@ gantt
     Task 3           : 2023-02-11  , 20d
     Task 4           : 2023-02-21  , 20d
 ```
+
+### Class Diagram
 
 ```mermaid
 classDiagram
@@ -44,6 +52,8 @@ classDiagram
     Animal <|-- Dog
 ```
 
+### State Diagram
+
 ```mermaid
 stateDiagram-v2
     [*] --> Idle
@@ -51,6 +61,8 @@ stateDiagram-v2
     Working --> Idle : stop
     Working --> Failed : error
 ```
+
+### Pie
 
 ```mermaid
 pie
@@ -61,12 +73,16 @@ pie
     "C++" : 10
 ```
 
+### erDiagram
+
 ```mermaid
 erDiagram
     CUSTOMER ||--o{ ORDER : places
     ORDER ||--|{ LINE-ITEM : contains
     CUSTOMER }|..|{ DELIVERY-ADDRESS : uses
 ```
+
+### Journey
 
 ```mermaid
 journey
@@ -79,6 +95,8 @@ journey
       Go downstairs: 5: Me
       Sit down: 5: Me
 ```
+
+### Quadrant Chart
 
 ```mermaid
 quadrantChart
@@ -97,8 +115,10 @@ quadrantChart
     Campaign F: [0.35, 0.78]
 ```
 
+### Requirement Diagram
+
 ```mermaid
-    requirementDiagram
+requirementDiagram
 
     requirement test_req {
     id: 1
@@ -114,6 +134,8 @@ quadrantChart
     test_entity - satisfies -> test_req
 ```
 
+### GitGraph
+
 ```mermaid
 gitGraph
    commit
@@ -127,6 +149,8 @@ gitGraph
    commit
    commit
 ```
+
+### MindMap
 
 ```mermaid
 mindmap
@@ -148,6 +172,8 @@ mindmap
       Mermaid
 ```
 
+### Timeline
+
 ```mermaid
 timeline
     title History of Social Media Platform
@@ -158,13 +184,7 @@ timeline
     2006 : Twitter
 ```
 
-```mermaid
-zenuml
-    title Demo
-    Alice->John: Hello John, how are you?
-    John->Alice: Great!
-    Alice->John: See you later!
-```
+### XYChart-Beta
 
 ```mermaid
 xychart-beta
@@ -174,6 +194,8 @@ xychart-beta
     bar [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]
     line [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]
 ```
+
+### Block Beta
 
 ```mermaid
 block-beta
@@ -190,4 +212,16 @@ columns 1
   ID --> D
   C --> D
   style B fill:#969,stroke:#333,stroke-width:4px
+```
+
+## Not yet supported
+
+### ZenUml
+
+```mermaid
+zenuml
+    title Demo
+    Alice->John: Hello John, how are you?
+    John->Alice: Great!
+    Alice->John: See you later!
 ```

--- a/src/Mermaid/hooks.test.ts
+++ b/src/Mermaid/hooks.test.ts
@@ -18,6 +18,14 @@ describe("isMermaidCode", () => {
       expect(result).toBe(true);
     });
 
+    it("Mindmap mermaid code exists", () => {
+      const mermaidCode = "mindmap mindmap root((foo bar)) Baz";
+
+      const result = isMermaidCode(mermaidCode);
+
+      expect(result).toBe(true);
+    });
+
     it("C4Container mermaid code exists", () => {
       const mermaidCode = "C4Container foo foo2 foo-->foo2";
 

--- a/src/Mermaid/hooks.test.ts
+++ b/src/Mermaid/hooks.test.ts
@@ -19,7 +19,31 @@ describe("isMermaidCode", () => {
     });
 
     it("Mindmap mermaid code exists", () => {
-      const mermaidCode = "mindmap mindmap root((foo bar)) Baz";
+      const mermaidCode = "mindmap root((foo bar)) Baz";
+
+      const result = isMermaidCode(mermaidCode);
+
+      expect(result).toBe(true);
+    });
+
+    it("Quadrant chart mermaid code exists", () => {
+      const mermaidCode = "quadrantChart x-axis Low Reach --> High Reach";
+
+      const result = isMermaidCode(mermaidCode);
+
+      expect(result).toBe(true);
+    });
+
+    it("xychart-beta chart mermaid code exists", () => {
+      const mermaidCode = "xychart-beta x-axis [jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec]";
+
+      const result = isMermaidCode(mermaidCode);
+
+      expect(result).toBe(true);
+    });
+
+    it("Block-beta chart mermaid code exists", () => {
+      const mermaidCode = "block-beta columns 1 db((\"DB\"))";
 
       const result = isMermaidCode(mermaidCode);
 

--- a/src/Mermaid/hooks.ts
+++ b/src/Mermaid/hooks.ts
@@ -15,7 +15,7 @@
  */
 
 const mermaidStart =
-  /^(\s*)(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|requirementDiagram|gitGraph|C4Context|C4Container|C4Component|C4Dynamic|C4Deployment|timeline)/gm;
+  /^(\s*)(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|requirementDiagram|gitGraph|C4Context|C4Container|C4Component|C4Dynamic|C4Deployment|timeline|mindmap)/gm;
 
 export const isMermaidCode = (code: string): boolean => {
   if (code.startsWith('%%{init')) {

--- a/src/Mermaid/hooks.ts
+++ b/src/Mermaid/hooks.ts
@@ -15,7 +15,7 @@
  */
 
 const mermaidStart =
-  /^(\s*)(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|requirementDiagram|gitGraph|C4Context|C4Container|C4Component|C4Dynamic|C4Deployment|timeline|mindmap)/gm;
+  /^(\s*)(graph|flowchart|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|requirementDiagram|gitGraph|C4Context|C4Container|C4Component|C4Dynamic|C4Deployment|timeline|mindmap|quadrantChart|xychart-beta|block-beta)/gm;
 
 export const isMermaidCode = (code: string): boolean => {
   if (code.startsWith('%%{init')) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5313,13 +5313,6 @@ cose-base@^1.0.0:
   dependencies:
     layout-base "^1.0.0"
 
-cose-base@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cose-base/-/cose-base-2.2.0.tgz#1c395c35b6e10bb83f9769ca8b817d614add5c01"
-  integrity sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==
-  dependencies:
-    layout-base "^2.0.0"
-
 cosmiconfig@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
@@ -5601,20 +5594,10 @@ cytoscape-cose-bilkent@^4.1.0:
   dependencies:
     cose-base "^1.0.0"
 
-cytoscape-fcose@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz#e4d6f6490df4fab58ae9cea9e5c3ab8d7472f471"
-  integrity sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==
-  dependencies:
-    cose-base "^2.2.0"
-
-cytoscape@^3.23.0:
-  version "3.28.1"
-  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.28.1.tgz#f32c3e009bdf32d47845a16a4cd2be2bbc01baf7"
-  integrity sha512-xyItz4O/4zp9/239wCcH8ZcFuuZooEeF8KHRmzjDfGdXsj3OG9MFSMA0pJE0uX3uCN/ygof6hHf4L7lst+JaDg==
-  dependencies:
-    heap "^0.2.6"
-    lodash "^4.17.21"
+cytoscape@^3.28.1:
+  version "3.30.2"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.30.2.tgz#94149707fb6547a55e3b44f03ffe232706212161"
+  integrity sha512-oICxQsjW8uSaRmn4UK/jkczKOqTrVqt5/1WL0POiJUT2EKNc9STM4hYFHv917yu55aTBMFNRzymlJhVAiWPCxw==
 
 "d3-array@1 - 2":
   version "2.12.1"
@@ -7619,11 +7602,6 @@ headers-polyfill@3.2.5:
   resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-3.2.5.tgz#6e67d392c9d113d37448fe45014e0afdd168faed"
   integrity sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==
 
-heap@^0.2.6:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.7.tgz#1e6adf711d3f27ce35a81fe3b7bd576c2260a8fc"
-  integrity sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==
-
 highlight.js@^10.4.1, highlight.js@~10.7.0:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
@@ -9082,6 +9060,13 @@ jws@^4.0.0:
     jwa "^2.0.0"
     safe-buffer "^5.0.1"
 
+katex@^0.16.9:
+  version "0.16.11"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.16.11.tgz#4bc84d5584f996abece5f01c6ad11304276a33f5"
+  integrity sha512-RQrI8rlHY92OLf3rho/Ts8i/XvjgguEjOkO1BEXcU3N8BqPpSzBNwV/G0Ukr+P/l3ivvJUE/Fa/CwbS6HesGNQ==
+  dependencies:
+    commander "^8.3.0"
+
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
@@ -9133,11 +9118,6 @@ layout-base@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-1.0.2.tgz#1291e296883c322a9dd4c5dd82063721b53e26e2"
   integrity sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==
-
-layout-base@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-2.0.1.tgz#d0337913586c90f9c2c075292069f5c2da5dd285"
-  integrity sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==
 
 leven@^3.1.0:
   version "3.1.0"
@@ -9615,23 +9595,23 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-mermaid@^10.3.0:
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-10.7.0.tgz#4fd5bfd60c0c5e5c42016a82905f06c4684ec53b"
-  integrity sha512-PsvGupPCkN1vemAAjScyw4pw34p4/0dZkSrqvAB26hUvJulOWGIwt35FZWmT9wPIi4r0QLa5X0PB4YLIGn0/YQ==
+mermaid@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-10.9.1.tgz#5f582c23f3186c46c6aa673e59eeb46d741b2ea6"
+  integrity sha512-Mx45Obds5W1UkW1nv/7dHRsbfMM1aOKA2+Pxs/IGHNonygDHwmng8xTHyS9z4KWVi0rbko8gjiBmuwwXQ7tiNA==
   dependencies:
     "@braintree/sanitize-url" "^6.0.1"
     "@types/d3-scale" "^4.0.3"
     "@types/d3-scale-chromatic" "^3.0.0"
-    cytoscape "^3.23.0"
+    cytoscape "^3.28.1"
     cytoscape-cose-bilkent "^4.1.0"
-    cytoscape-fcose "^2.1.0"
     d3 "^7.4.0"
     d3-sankey "^0.12.3"
     dagre-d3-es "7.0.10"
     dayjs "^1.11.7"
     dompurify "^3.0.5"
     elkjs "^0.9.0"
+    katex "^0.16.9"
     khroma "^2.0.0"
     lodash-es "^4.17.21"
     mdast-util-from-markdown "^1.3.0"


### PR DESCRIPTION
* The addon was missing support for MindMaps, Quadrants, XY, and Block-Beta. 
   * Added Support for those types.

* Added instructions for contributors to help out.
   * Let me know if you'd like me to change anything. I was a little iffy on the instructions. It's seems like there should be something more general purpose, but a lot of it is all about creating a plugin from scratch.

* Bumped mermaid to the latest version.


Screenshots of new diagrams rendering in my local vanilla Backstage instance:
![image](https://github.com/user-attachments/assets/6e36cd7c-4279-45f2-8b47-5829f0f6531a)

![image](https://github.com/user-attachments/assets/16d33751-6e6f-4cd2-9ae5-da8552b3eafc)

![image](https://github.com/user-attachments/assets/a548f83b-ed68-4503-a654-32ae396a9e63)

![image](https://github.com/user-attachments/assets/da0b5737-6e82-43dc-8c7a-4d032ededf57)

Mermaid adds Katex support in [10.8](https://github.com/mermaid-js/mermaid/releases/tag/v10.9.0)

![image](https://github.com/user-attachments/assets/0e0fe873-bbe8-409c-97b9-c906b7b081b1)

Fixes https://github.com/johanneswuerbach/backstage-plugin-techdocs-addon-mermaid/issues/54