### PR TITLE
Fix typescript declaration

### DIFF
--- a/src/alpha.ts
+++ b/src/alpha.ts
@@ -1,14 +1,19 @@
-import { AddonBlueprint } from "@backstage/plugin-techdocs-react/alpha";
+import {
+  AddonBlueprint,
+  TechDocsAddonOptions,
+} from "@backstage/plugin-techdocs-react/alpha";
 import { MermaidAddon } from "./Mermaid";
 import { createFrontendModule } from "@backstage/frontend-plugin-api";
 
+const mermaidAddonParams: TechDocsAddonOptions = {
+  name: "Mermaid",
+  location: "Content",
+  component: MermaidAddon,
+};
+
 export const techDocsMermaidAddon = AddonBlueprint.make({
   name: "mermaid",
-  params: {
-    name: "Mermaid",
-    location: "Content",
-    component: MermaidAddon,
-  },
+  params: mermaidAddonParams,
 });
 
 export const techDocsMermaidAddonModule = createFrontendModule({


### PR DESCRIPTION
Typescript is unable to infer the `params` type correctly since this is coming from a internal/private path (`/alpha`) of `backstage/plugin-techdocs-react`. Explicitly declaring what type params is should fix this issue.

Checked for the correct type  `dist-types/alpha.d.ts` after running `yarn tsc`