### PR TITLE
fix: Update pan to work the same at any zoom level

### DIFF
--- a/src/Mermaid/zoomHandler.ts
+++ b/src/Mermaid/zoomHandler.ts
@@ -61,6 +61,8 @@ export class ZoomHandler {
     const zb = this.createZoomBehavior();
     this.attachZoomBehavior(zb);
     this.attachEventListeners(zb);
+    // Disable text selection permanently
+    this.svgEl.style.userSelect = 'none';
   }
 
   /**
@@ -176,8 +178,14 @@ export class ZoomHandler {
 
     event.preventDefault();
 
-    const dx = event.clientX - this.state.startX;
-    const dy = event.clientY - this.state.startY;
+    // Convert current mouse position to SVG coordinates
+    const [currentX, currentY] = pointer(event, this.svgEl);
+    // Convert the starting mouse position to SVG coordinates
+    const [startX, startY] = pointer({ clientX: this.state.startX, clientY: this.state.startY }, this.svgEl);
+
+    // Calculate the movement delta in SVG coordinate space
+    const dx = currentX - startX;
+    const dy = currentY - startY;
 
     const transform = select(this.g).attr('transform');
     let currentScale = 1;


### PR DESCRIPTION
**Description**
In the current version of pan/zoom the pan functionality was undesirable at large zoom levels. In addition, the pan behavior would erroneously highlight parts of the text in the SVGs.

**Fixes**

1. Ensure Pan behavior is the same across all zoom levels. 
2. Prevent highlight from occurring during SVG creation. 