### PR TITLE
Export module as default from alpha entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,16 @@
   "version": "0.22.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "typesVersions": {
+    "*": {
+      "alpha": [
+        "src/alpha.ts"
+      ],
+      "package.json": [
+        "package.json"
+      ]
+    }
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",
@@ -11,11 +21,9 @@
     "registry": "https://registry.npmjs.org"
   },
   "backstage": {
-    "role": "frontend-plugin",
-    "pluginId": "techdocs-addon-mermaid",
-    "pluginPackages": [
-      "backstage-plugin-techdocs-addon-mermaid"
-    ]
+    "role": "frontend-plugin-module",
+    "pluginId": "techdocs",
+    "pluginPackage": "@backstage/plugin-techdocs"
   },
   "keywords": [
     "backstage",
@@ -23,6 +31,11 @@
     "mermaid"
   ],
   "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./alpha": "./src/alpha.ts",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/src/alpha.ts
+++ b/src/alpha.ts
@@ -20,3 +20,5 @@ export const techDocsMermaidAddonModule = createFrontendModule({
   pluginId: "techdocs",
   extensions: [techDocsMermaidAddon],
 });
+
+export { techDocsMermaidAddonModule as default };


### PR DESCRIPTION
In order to be used with [feature discovery](https://backstage.io/docs/frontend-system/architecture/app/#feature-discovery) in a Backstage app, plugins or modules need to provide a default export which is then loaded within the app. This PR exports the `techDocsMermaidAddonModule` frontend module as the default export from the `/alpha` entrypoint, along with some updates to `package.json` to package metadata to coincide with the change. Apps not using the new frontend system should continue to work as before.