### PR TITLE
zoom: Improve keyboard shortcuts

### DIFF
--- a/src/Mermaid/zoomHandler.ts
+++ b/src/Mermaid/zoomHandler.ts
@@ -171,11 +171,6 @@ export class ZoomHandler {
    * @param zb - The D3 zoom behavior to use for transformations
    */
   private handleMouseMove(event: MouseEvent, zb: ZoomBehavior<HTMLElement, unknown>): void {
-    if (!event.metaKey && !event.ctrlKey) {
-      this.handleMouseUp();
-      return;
-    }
-
     event.preventDefault();
 
     // Convert current mouse position to SVG coordinates

--- a/src/Mermaid/zoomHandler.ts
+++ b/src/Mermaid/zoomHandler.ts
@@ -118,7 +118,8 @@ export class ZoomHandler {
    */
   private attachMouseListeners(zb: ZoomBehavior<HTMLElement, unknown>): void {
     this.container.addEventListener('mousedown', (event) => {
-      if (event.metaKey || event.ctrlKey) {
+      // Allow panning by holding meta, ctrl or the middle mouse button
+      if (event.metaKey || event.ctrlKey || event.button == 1) {
         this.handleMouseDown(event);
       }
     });


### PR DESCRIPTION
This changes the keyboard shortcuts behavior a tiny bit, allowing users to pan with middle mouse button without holding ctrl, and allowing them to keep panning the diagram after letting go of ctrl. 
This is closer to the behavior of mermaid.live and other diagram viewers.