### PR TITLE
Do not disable selection if zooming is enabled

### DIFF
--- a/src/Mermaid/zoomHandler.test.ts
+++ b/src/Mermaid/zoomHandler.test.ts
@@ -147,7 +147,7 @@ describe('ZoomHandler', () => {
       const mouseUpEvent = new MouseEvent('mouseup');
       document.dispatchEvent(mouseUpEvent);
 
-      expect(mockDiagContainer.style.cursor).toBe('default');
+      expect(mockDiagContainer.style.cursor).toBe('auto');
     });
   });
 });

--- a/src/Mermaid/zoomHandler.ts
+++ b/src/Mermaid/zoomHandler.ts
@@ -213,6 +213,6 @@ export class ZoomHandler {
    */
   private handleMouseUp(): void {
     this.state.isPanning = false;
-    this.container.style.cursor = 'default';
+    this.container.style.cursor = 'auto';
   }
 } 


### PR DESCRIPTION
Being able to select text on the diagram is useful, and there is no reason to disable it