### PR TITLE
fix: handle mermaid render errors gracefully

### DIFF
--- a/src/Mermaid/Mermaid.test.tsx
+++ b/src/Mermaid/Mermaid.test.tsx
@@ -16,6 +16,7 @@
 
 import { TechDocsAddonTester } from '@backstage/plugin-techdocs-addons-test-utils';
 import { screen } from 'shadow-dom-testing-library';
+import mermaid from 'mermaid';
 
 import { Mermaid } from '../plugin';
 import { selectConfig } from './Mermaid';
@@ -73,6 +74,33 @@ describe('Mermaid', () => {
       .renderWithEffects();
 
     expect(screen.getByShadowTestId('mermaid-test')).toHaveStyle('display: none')
+  });
+
+  describe('error handling', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('restores original element and logs error when render fails', async () => {
+      const error = new Error('Parse error');
+      jest.spyOn(mermaid, 'render').mockRejectedValue(error);
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await TechDocsAddonTester.buildAddonsInTechDocs([
+        <Mermaid />,
+      ])
+        .withDom(<body>
+          <pre className="mermaid" data-testid="mermaid-test">
+            <code>flowchart LR\ninvalid syntax &&&</code>
+          </pre>
+        </body>)
+        .renderWithEffects();
+
+      const el = screen.getByShadowTestId('mermaid-test');
+      expect(el).not.toHaveStyle('display: none');
+      expect(el.nextSibling).toBeNull();
+      expect(consoleError).toHaveBeenCalledWith('Failed to render mermaid diagram', error);
+    });
   });
 
   describe('selectConfig', () => {

--- a/src/Mermaid/Mermaid.tsx
+++ b/src/Mermaid/Mermaid.tsx
@@ -56,18 +56,24 @@ const makeDiagram = async (el: HTMLDivElement | HTMLPreElement, diagramText: str
   el.parentNode?.insertBefore(diagramElement, el.nextSibling);
 
   const id = `mermaid-${diagramId++}`
-  const { svg, bindFunctions } = await mermaid.render(id, diagramText);
-  diagramElement.innerHTML = svg
-  bindFunctions?.(diagramElement);
-  
-  if (properties.enableZoom) {
-    const svgEl = diagramElement.querySelector('svg');
-    const zoomHandler = new ZoomHandler(
-     diagramElement,
-     svgEl as SVGSVGElement,
-     properties.zoomOptions,
-    );
-    zoomHandler.initialize();
+  try {
+    const { svg, bindFunctions } = await mermaid.render(id, diagramText);
+    diagramElement.innerHTML = svg
+    bindFunctions?.(diagramElement);
+
+    if (properties.enableZoom) {
+      const svgEl = diagramElement.querySelector('svg');
+      const zoomHandler = new ZoomHandler(
+       diagramElement,
+       svgEl as SVGSVGElement,
+       properties.zoomOptions,
+      );
+      zoomHandler.initialize();
+    }
+  } catch (e) {
+    el.style.display = ''
+    diagramElement.remove()
+    console.error('Failed to render mermaid diagram', e)
   }
 }
 
@@ -90,7 +96,7 @@ export const MermaidAddon = (properties: MermaidProps) => {
     if (properties.layoutLoaders) {
       mermaid.registerLayoutLoaders(properties.layoutLoaders);
     }
-    mermaid.initialize(config);
+    mermaid.initialize({ suppressErrorRendering: true, ...config });
     setInitialized(true);
   }, [initialized, properties, theme.palette.type]);
 


### PR DESCRIPTION
## Problem 🧜🏽‍♀️ 
When a Mermaid diagram contains invalid syntax, `mermaid.render()` rejects its promise. Because the call was not wrapped in a try/catch, this produced an unhandled promise rejection that could crash the page in some Backstage setups.
Additionally, `mermaid.initialize()` was not setting `suppressErrorRendering: true`, allowing Mermaid to inject an error SVG directly into the DOM outside of React's control.

## Changes
- Wrap `mermaid.render()` in a try/catch. On failure, the original code block is restored and the empty placeholder removed.
- Log the error so developers can diagnose failures.
- Pass `suppressErrorRendering: true` to `mermaid.initialize()` to prevent Mermaid from injecting its own error SVG into the DOM. This is set as a safe default but can be overridden via the `config` prop if needed.
- Add a test covering the error recovery path and verifying the error is logged.

### Note
Errors are logged via `console.error` rather than `errorApiRef` — since the addon has no UI of its own, a toast notification for every parse error felt overly noisy. 