### PR TITLE
fix: Fix support of mermaid zoom in Backstage NFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,14 @@ The zoom functionality can be configured using the following options:
 
 ```typescript
 interface ZoomOptions {
-  /** 
+  /**
    * Defines the minimum and maximum zoom scale limits.
    * Example: [0.1, 10] allows zooming out to 10% and in to 1000%
    * Default: [0.1, 10]
    */
   scaleExtent?: [number, number];
 
-  /** 
+  /**
    * Defines the boundaries for panning the diagram.
    * Format: [[xmin, ymin], [xmax, ymax]]
    * Example: [[-1000, -1000], [1000, 1000]] limits panning to a 2000x2000 area
@@ -103,10 +103,12 @@ interface ZoomOptions {
 }
 ```
 
+### Legacy Frontend System
+
 To enable zoom functionality, add the `enableZoom` prop and optionally configure the zoom behavior:
 
 ```typescript
-<Mermaid 
+<Mermaid
   enableZoom
   zoomOptions={{
     scaleExtent: [0.1, 10], // Optional: Set min/max zoom scale
@@ -114,6 +116,28 @@ To enable zoom functionality, add the `enableZoom` prop and optionally configure
   }}
 />
 ```
+
+### New Frontend System
+
+When using the new frontend system, zoom and pan are configured via `app-config.yaml`
+under the `techdocs.addons.mermaid` key:
+
+```yaml
+# app-config.yaml
+techdocs:
+  addons:
+    mermaid:
+      enableZoom: true
+      zoomOptions:
+        scaleExtent: [0.1, 10]           # Optional: min/max zoom scale
+        translateExtent:                   # Optional: pan boundaries
+          - [-1000, -1000]
+          - [1000, 1000]
+```
+
+No code changes are needed beyond the standard module registration shown in
+the [Getting Started](#getting-started) section — the addon reads the
+configuration automatically at runtime.
 
 ## Auto-Detection vs. Manual Detection
 

--- a/config.d.ts
+++ b/config.d.ts
@@ -1,0 +1,30 @@
+export interface Config {
+  techdocs?: {
+    addons?: {
+      mermaid?: {
+        /**
+         * Whether to enable zoom and pan on mermaid diagrams.
+         *
+         * @visibility frontend
+         */
+        enableZoom?: boolean;
+
+        zoomOptions?: {
+          /**
+           * D3 zoom scale extent as [min, max].
+           *
+           * @visibility frontend
+           */
+          scaleExtent?: [number, number];
+
+          /**
+           * D3 zoom translate extent as [[x0, y0], [x1, y1]].
+           *
+           * @visibility frontend
+           */
+          translateExtent?: [[number, number], [number, number]];
+        };
+      };
+    };
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "backstage-plugin-techdocs-addon-mermaid",
   "version": "0.25.0",
+  "configSchema": "config.d.ts",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "typesVersions": {
@@ -103,7 +104,8 @@
     "typescript": "~5.6.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "config.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/src/alpha.ts
+++ b/src/alpha.ts
@@ -1,14 +1,55 @@
+import { createElement } from "react";
 import {
   AddonBlueprint,
   TechDocsAddonOptions,
 } from "@backstage/plugin-techdocs-react/alpha";
 import { MermaidAddon } from "./Mermaid";
-import { createFrontendModule } from "@backstage/frontend-plugin-api";
+import {
+  createFrontendModule,
+  useApi,
+  configApiRef,
+} from "@backstage/frontend-plugin-api";
+import type { MermaidProps } from "./Mermaid/props";
+
+/**
+ * Wrapper that reads zoom configuration from app-config.yaml and forwards
+ * it as props to MermaidAddon.
+ *
+ * When no `techdocs.addons.mermaid` config is present, MermaidAddon is
+ * rendered with no props — preserving the original behaviour.
+ *
+ * Supported app-config keys:
+ *   techdocs.addons.mermaid.enableZoom              — boolean (default: false)
+ *   techdocs.addons.mermaid.zoomOptions.scaleExtent  — [min, max]
+ *   techdocs.addons.mermaid.zoomOptions.translateExtent — [[xmin, ymin], [xmax, ymax]]
+ */
+const ConfiguredMermaidAddon = () => {
+  const config = useApi(configApiRef);
+  const mermaidConfig = config.getOptionalConfig("techdocs.addons.mermaid");
+
+  const props: MermaidProps = {};
+
+  if (mermaidConfig) {
+    props.enableZoom = mermaidConfig.getOptionalBoolean("enableZoom") ?? false;
+
+    const zoomConfig = mermaidConfig.getOptionalConfig("zoomOptions");
+    if (zoomConfig) {
+      props.zoomOptions = {
+        scaleExtent: zoomConfig.getOptional<[number, number]>("scaleExtent"),
+        translateExtent: zoomConfig.getOptional<
+          [[number, number], [number, number]]
+        >("translateExtent"),
+      };
+    }
+  }
+
+  return createElement(MermaidAddon, props);
+};
 
 const mermaidAddonParams: TechDocsAddonOptions = {
   name: "Mermaid",
   location: "Content",
-  component: MermaidAddon,
+  component: ConfiguredMermaidAddon,
 };
 
 export const techDocsMermaidAddon = AddonBlueprint.make({


### PR DESCRIPTION
In the following PR, support was added for zooming on diagrams:
- https://github.com/johanneswuerbach/backstage-plugin-techdocs-addon-mermaid/pull/66

However this only is supported when using the legacy Backstage frontend, when using the new frontend system, there are no options to pass in the config to enable the zoom.

This update adds support for passing config to the new frontend loaded add-on plugin.

Local tested and it correctly zooms:
<img width="1039" height="564" alt="image" src="https://github.com/user-attachments/assets/69beb76e-6af7-45f2-ae54-647721c25dd3" />
