### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,5 +112,9 @@
     "url": "https://github.com/johanneswuerbach/backstage-plugin-techdocs-addon-mermaid",
     "directory": "."
   },
+  "homepage": "https://github.com/johanneswuerbach/backstage-plugin-techdocs-addon-mermaid#readme",
+  "bugs": {
+    "url": "https://github.com/johanneswuerbach/backstage-plugin-techdocs-addon-mermaid/issues"
+  },
   "packageManager": "yarn@4.8.1"
 }


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata pointing to the repository README
- add `bugs.url` metadata pointing to the issue tracker
- keep runtime code, dependencies, exports, and package contents unchanged

## Validation
- `node -e "const p=require('./package.json'); if(p.name!=='backstage-plugin-techdocs-addon-mermaid') throw new Error('bad name'); if(p.homepage!=='https://github.com/johanneswuerbach/backstage-plugin-techdocs-addon-mermaid#readme') throw new Error('bad homepage'); if(p.bugs?.url!=='https://github.com/johanneswuerbach/backstage-plugin-techdocs-addon-mermaid/issues') throw new Error('bad bugs'); console.log('metadata ok')"`
- `npm view backstage-plugin-techdocs-addon-mermaid homepage bugs repository --json`
- `yarn install --immutable --mode=skip-build`
- `yarn tsc`
- `yarn build`
- `yarn pack --dry-run --json`
- `yarn test --watch=false`
- `git diff --check`

Note: `yarn lint` currently reports two existing source lint errors in `src/Mermaid/Mermaid.tsx` and `src/Mermaid/zoomHandler.ts`; this PR only changes package metadata.