### PR TITLE
Support Mermaid configuration in Backstage NFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,72 @@ graph TD;
 
 ~~~
 
+## Mermaid Configuration
+
+The plugin supports customizing the Mermaid configuration for light and dark themes, as well as a shared base configuration. The available options are:
+
+- `lightConfig` — Mermaid configuration applied when the Backstage theme is set to light mode.
+- `darkConfig` — Mermaid configuration applied when the Backstage theme is set to dark mode.
+- `config` — Shared configuration that is deep-merged on top of the selected theme configuration. Values here take precedence over `lightConfig`/`darkConfig`.
+
+Each option follows this schema:
+
+```typescript
+interface MermaidConfig {
+  // Theme for the diagram. Options: 'default' | 'base' | 'dark' | 'forest' | 'neutral' | 'null'
+  theme?: string;
+  // Custom theme variables to override the default theme colors, fonts, etc.
+  themeVariables?: Record<string, any>;
+  // Custom CSS to apply to the diagram
+  themeCSS?: string;
+  // Font family and size for the diagram
+  fontFamily?: string;
+  fontSize?: number;
+  // ... any other Mermaid configuration options
+}
+```
+
+See [Mermaid Config Schema](https://mermaid.ai/open-source/config/schema-docs/config.html) for all configuration options.
+
+### Legacy Frontend System
+
+Pass `lightConfig`, `darkConfig`, and `config` directly as props:
+
+```typescript jsx
+<Mermaid
+  lightConfig={{ theme: "default", themeVariables: { primaryColor: "#bb2528" } }}
+  darkConfig={{ theme: "dark", themeVariables: { primaryColor: "#bb2528" } }}
+  config={{ fontFamily: "Arial", fontSize: 14 }}
+/>
+```
+
+### New Frontend System
+
+When using the new frontend system, these options are configured via `app-config.yaml`
+under the `techdocs.addons.mermaid` key:
+
+```yaml
+# app-config.yaml
+techdocs:
+  addons:
+    mermaid:
+      lightConfig:
+        theme: default
+        themeVariables:
+          primaryColor: "#bb2528"
+      darkConfig:
+        theme: dark
+        themeVariables:
+          primaryColor: "#bb2528"
+      config:
+        fontFamily: Arial
+        fontSize: 14
+```
+
+No code changes are needed beyond the standard module registration shown in
+the [Getting Started](#getting-started) section — the addon reads the
+configuration automatically at runtime.
+
 ## Zoom and Pan Functionality
 
 The plugin supports interactive zoom and pan functionality for Mermaid diagrams. This allows users to:

--- a/config.d.ts
+++ b/config.d.ts
@@ -3,6 +3,27 @@ export interface Config {
     addons?: {
       mermaid?: {
         /**
+         * Light theme configuration.
+         *
+         * @deepVisibility frontend
+         */
+        lightConfig?: object;
+
+        /**
+         * Dark theme configuration.
+         *
+         * @deepVisibility frontend
+         */
+        darkConfig?: object;
+
+        /**
+         * Shared configuration.
+         *
+         * @deepVisibility frontend
+         */
+        config?: object;
+
+        /**
          * Whether to enable zoom and pan on mermaid diagrams.
          *
          * @visibility frontend

--- a/src/alpha.ts
+++ b/src/alpha.ts
@@ -10,6 +10,7 @@ import {
   configApiRef,
 } from "@backstage/frontend-plugin-api";
 import type { MermaidProps } from "./Mermaid/props";
+import type { MermaidConfig } from "mermaid";
 
 /**
  * Wrapper that reads zoom configuration from app-config.yaml and forwards
@@ -19,6 +20,9 @@ import type { MermaidProps } from "./Mermaid/props";
  * rendered with no props — preserving the original behaviour.
  *
  * Supported app-config keys:
+ *   techdocs.addons.mermaid.lightConfig             — MermaidConfig
+ *   techdocs.addons.mermaid.darkConfig              — MermaidConfig
+ *   techdocs.addons.mermaid.config                  — MermaidConfig
  *   techdocs.addons.mermaid.enableZoom              — boolean (default: false)
  *   techdocs.addons.mermaid.zoomOptions.scaleExtent  — [min, max]
  *   techdocs.addons.mermaid.zoomOptions.translateExtent — [[xmin, ymin], [xmax, ymax]]
@@ -30,6 +34,9 @@ const ConfiguredMermaidAddon = () => {
   const props: MermaidProps = {};
 
   if (mermaidConfig) {
+    props.lightConfig = mermaidConfig.getOptional<MermaidConfig>("lightConfig");
+    props.darkConfig = mermaidConfig.getOptional<MermaidConfig>("darkConfig");
+    props.config = mermaidConfig.getOptional<MermaidConfig>("config");
     props.enableZoom = mermaidConfig.getOptionalBoolean("enableZoom") ?? false;
 
     const zoomConfig = mermaidConfig.getOptionalConfig("zoomOptions");


### PR DESCRIPTION
After upgrading to the new frontend system, I noticed that it was no longer possible to pass the `lightConfig`, `darkConfig` and `config` props. So I made them configurable via `app-config.yaml`.

Tested in a local Backstage app, here's some logging in `ConfiguredMermaidAddon` to demonstrate:
<img width="3190" height="210" alt="image" src="https://github.com/user-attachments/assets/be8c979f-c842-4141-8329-a19d2c167b95" />